### PR TITLE
feat: add provider dashboard

### DIFF
--- a/Market/angular.json
+++ b/Market/angular.json
@@ -151,7 +151,8 @@
   "cli": {
     "schematicCollections": [
       "@ionic/angular-toolkit"
-    ]
+    ],
+    "analytics": false
   },
   "schematics": {
     "@ionic/angular-toolkit:component": {

--- a/Market/src/app/app.routes.ts
+++ b/Market/src/app/app.routes.ts
@@ -6,6 +6,30 @@ export const routes: Routes = [
     loadComponent: () => import('./home/home.page').then((m) => m.HomePage),
   },
   {
+    path: 'providers',
+    children: [
+      {
+        path: 'dashboard',
+        loadComponent: () =>
+          import('./providers/dashboard/providers-dashboard.page').then(
+            (m) => m.ProvidersDashboardPage,
+          ),
+      },
+      {
+        path: 'preferences',
+        loadComponent: () =>
+          import('./providers/preferences/provider-preferences.page').then(
+            (m) => m.ProviderPreferencesPage,
+          ),
+      },
+      {
+        path: '',
+        pathMatch: 'full',
+        redirectTo: 'dashboard',
+      },
+    ],
+  },
+  {
     path: '',
     redirectTo: 'home',
     pathMatch: 'full',

--- a/Market/src/app/providers/dashboard/providers-dashboard.page.html
+++ b/Market/src/app/providers/dashboard/providers-dashboard.page.html
@@ -1,0 +1,101 @@
+<ion-header translucent="true">
+  <ion-toolbar>
+    <ion-title>Panel del proveedor</ion-title>
+    <ion-buttons slot="end">
+      <ion-button color="medium" (click)="editPreferences()">
+        <ion-icon slot="start" [icon]="settingsOutline"></ion-icon>
+        Editar configuración
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content fullscreen>
+  <ng-container *ngIf="preferences$ | async as preferences; else loading">
+    <div class="page-container">
+      <section class="module-section">
+        <ng-container *ngIf="preferences.modules.agenda; else agendaDisabled">
+          <app-calendar-widget [appointments]="sampleAppointments"></app-calendar-widget>
+        </ng-container>
+        <ng-template #agendaDisabled>
+          <ion-card class="disabled-card">
+            <ion-card-header>
+              <ion-card-title>Agenda de citas</ion-card-title>
+            </ion-card-header>
+            <ion-card-content>
+              <p>Activa este módulo para gestionar tus citas directamente desde el panel.</p>
+              <ion-button expand="block" fill="outline" (click)="editPreferences()">
+                Habilitar agenda
+              </ion-button>
+            </ion-card-content>
+          </ion-card>
+        </ng-template>
+      </section>
+
+      <section class="module-section">
+        <ng-container *ngIf="preferences.modules.inventory; else inventoryDisabled">
+          <app-inventory-widget [inventory]="sampleInventory"></app-inventory-widget>
+        </ng-container>
+        <ng-template #inventoryDisabled>
+          <ion-card class="disabled-card">
+            <ion-card-header>
+              <ion-card-title>Gestión de productos</ion-card-title>
+            </ion-card-header>
+            <ion-card-content>
+              <p>
+                Cuando actives este módulo podrás llevar el control de tu inventario y actualizarlo con un clic.
+              </p>
+              <ion-button expand="block" fill="outline" (click)="editPreferences()">
+                Habilitar gestión de productos
+              </ion-button>
+            </ion-card-content>
+          </ion-card>
+        </ng-template>
+      </section>
+
+      <section class="module-section">
+        <ng-container *ngIf="preferences.modules.services; else servicesDisabled">
+          <app-services-widget [services]="preferences.servicesOffered"></app-services-widget>
+        </ng-container>
+        <ng-template #servicesDisabled>
+          <ion-card class="disabled-card">
+            <ion-card-header>
+              <ion-card-title>Servicios ofrecidos</ion-card-title>
+            </ion-card-header>
+            <ion-card-content>
+              <p>Activa este módulo para mostrar los servicios que prestas en tu perfil profesional.</p>
+              <ion-button expand="block" fill="outline" (click)="editPreferences()">
+                Habilitar servicios ofrecidos
+              </ion-button>
+            </ion-card-content>
+          </ion-card>
+        </ng-template>
+      </section>
+
+      <section class="module-section">
+        <ng-container *ngIf="preferences.modules.species; else speciesDisabled">
+          <app-species-widget [species]="preferences.speciesAttended"></app-species-widget>
+        </ng-container>
+        <ng-template #speciesDisabled>
+          <ion-card class="disabled-card">
+            <ion-card-header>
+              <ion-card-title>Especies atendidas</ion-card-title>
+            </ion-card-header>
+            <ion-card-content>
+              <p>Configura este módulo para informar qué especies puedes atender en tu consultorio.</p>
+              <ion-button expand="block" fill="outline" (click)="editPreferences()">
+                Habilitar especies atendidas
+              </ion-button>
+            </ion-card-content>
+          </ion-card>
+        </ng-template>
+      </section>
+    </div>
+  </ng-container>
+
+  <ng-template #loading>
+    <div class="loading-state">
+      <ion-spinner name="crescent"></ion-spinner>
+    </div>
+  </ng-template>
+</ion-content>

--- a/Market/src/app/providers/dashboard/providers-dashboard.page.scss
+++ b/Market/src/app/providers/dashboard/providers-dashboard.page.scss
@@ -1,0 +1,25 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.page-container {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem;
+}
+
+.module-section {
+  display: block;
+}
+
+.disabled-card p {
+  color: var(--ion-color-medium);
+}
+
+.loading-state {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/Market/src/app/providers/dashboard/providers-dashboard.page.ts
+++ b/Market/src/app/providers/dashboard/providers-dashboard.page.ts
@@ -1,0 +1,88 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import {
+  IonButton,
+  IonButtons,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonSpinner,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
+import { settingsOutline } from 'ionicons/icons';
+import { ProviderPreferencesService } from '../services/provider-preferences.service';
+import { CalendarWidgetComponent } from './widgets/calendar-widget.component';
+import { InventoryWidgetComponent } from './widgets/inventory-widget.component';
+import { ServicesWidgetComponent } from './widgets/services-widget.component';
+import { SpeciesWidgetComponent } from './widgets/species-widget.component';
+
+@Component({
+  selector: 'app-providers-dashboard',
+  templateUrl: './providers-dashboard.page.html',
+  styleUrls: ['./providers-dashboard.page.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonButton,
+    IonButtons,
+    IonIcon,
+    IonContent,
+    IonSpinner,
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardContent,
+    CalendarWidgetComponent,
+    InventoryWidgetComponent,
+    ServicesWidgetComponent,
+    SpeciesWidgetComponent,
+  ],
+})
+export class ProvidersDashboardPage {
+  private readonly preferencesService = inject(ProviderPreferencesService);
+  private readonly router = inject(Router);
+
+  protected readonly settingsOutline = settingsOutline;
+  protected readonly preferences$ = this.preferencesService.preferences$;
+
+  protected readonly sampleAppointments = [
+    {
+      id: '1',
+      title: 'Consulta general',
+      date: 'Lunes 10:00 a. m.',
+      owner: 'Luna (canino)',
+    },
+    {
+      id: '2',
+      title: 'Vacunación',
+      date: 'Martes 4:00 p. m.',
+      owner: 'Simón (felino)',
+    },
+  ];
+
+  protected readonly sampleInventory = [
+    {
+      id: '1',
+      name: 'Alimento balanceado 10kg',
+      stock: 8,
+    },
+    {
+      id: '2',
+      name: 'Antipulgas tópico',
+      stock: 15,
+    },
+  ];
+
+  protected editPreferences(): void {
+    void this.router.navigate(['/providers/preferences']);
+  }
+}

--- a/Market/src/app/providers/dashboard/widgets/calendar-widget.component.html
+++ b/Market/src/app/providers/dashboard/widgets/calendar-widget.component.html
@@ -1,0 +1,33 @@
+<ion-card>
+  <ion-card-header>
+    <ion-card-title>Agenda de citas</ion-card-title>
+  </ion-card-header>
+  <ion-card-content>
+    <ion-list lines="none">
+      <ion-item *ngFor="let appointment of appointments; trackBy: trackById">
+        <ion-icon slot="start" [icon]="calendarOutline"></ion-icon>
+        <ion-label>
+          <h3>{{ appointment.title }}</h3>
+          <p>{{ appointment.date }} · {{ appointment.owner }}</p>
+        </ion-label>
+        <ion-buttons slot="end">
+          <ion-button fill="clear" color="primary">
+            <ion-icon slot="icon-only" [icon]="createOutline"></ion-icon>
+          </ion-button>
+          <ion-button fill="clear" color="success">
+            <ion-icon slot="icon-only" [icon]="addOutline"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      </ion-item>
+    </ion-list>
+    <div class="widget-actions" *ngIf="appointments.length === 0">
+      <p class="empty-message">
+        Aún no tienes citas programadas. Utiliza la agenda para crear tu primera cita.
+      </p>
+      <ion-button expand="block" color="primary">Gestionar agenda</ion-button>
+    </div>
+    <div class="widget-actions" *ngIf="appointments.length > 0">
+      <ion-button expand="block" color="primary">Ver agenda completa</ion-button>
+    </div>
+  </ion-card-content>
+</ion-card>

--- a/Market/src/app/providers/dashboard/widgets/calendar-widget.component.scss
+++ b/Market/src/app/providers/dashboard/widgets/calendar-widget.component.scss
@@ -1,0 +1,20 @@
+:host {
+  display: block;
+}
+
+ion-item {
+  --inner-padding-end: 0;
+}
+
+.widget-actions {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.empty-message {
+  margin: 0;
+  color: var(--ion-color-medium);
+  text-align: center;
+}

--- a/Market/src/app/providers/dashboard/widgets/calendar-widget.component.ts
+++ b/Market/src/app/providers/dashboard/widgets/calendar-widget.component.ts
@@ -1,0 +1,51 @@
+import { Component, Input } from '@angular/core';
+import {
+  IonButton,
+  IonButtons,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
+import { addOutline, calendarOutline, createOutline } from 'ionicons/icons';
+
+export interface CalendarAppointment {
+  id: string;
+  title: string;
+  date: string;
+  owner: string;
+}
+
+@Component({
+  selector: 'app-calendar-widget',
+  templateUrl: './calendar-widget.component.html',
+  styleUrls: ['./calendar-widget.component.scss'],
+  standalone: true,
+  imports: [
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonIcon,
+    IonButtons,
+    IonButton,
+  ],
+})
+export class CalendarWidgetComponent {
+  protected readonly calendarOutline = calendarOutline;
+  protected readonly addOutline = addOutline;
+  protected readonly createOutline = createOutline;
+
+  @Input() appointments: CalendarAppointment[] = [];
+
+  trackById(_index: number, appointment: CalendarAppointment): string {
+    return appointment.id;
+  }
+}

--- a/Market/src/app/providers/dashboard/widgets/inventory-widget.component.html
+++ b/Market/src/app/providers/dashboard/widgets/inventory-widget.component.html
@@ -1,0 +1,35 @@
+<ion-card>
+  <ion-card-header>
+    <ion-card-title>Gestión de productos</ion-card-title>
+  </ion-card-header>
+  <ion-card-content>
+    <ion-list lines="none" *ngIf="inventory.length > 0; else emptyInventory">
+      <ion-item *ngFor="let item of inventory; trackBy: trackById">
+        <ion-icon slot="start" [icon]="storefrontOutline"></ion-icon>
+        <ion-label>
+          <h3>{{ item.name }}</h3>
+          <p>Stock disponible</p>
+        </ion-label>
+        <ion-badge color="tertiary">{{ item.stock }}</ion-badge>
+        <ion-button slot="end" fill="clear" color="primary">
+          <ion-icon slot="icon-only" [icon]="createOutline"></ion-icon>
+        </ion-button>
+      </ion-item>
+    </ion-list>
+
+    <ng-template #emptyInventory>
+      <p class="empty-message">
+        Aún no tienes productos registrados. Empieza a construir tu inventario para hacer seguimiento.
+      </p>
+      <ion-button expand="block" color="primary">Crear producto</ion-button>
+    </ng-template>
+
+    <div class="widget-actions" *ngIf="inventory.length > 0">
+      <ion-button expand="block" color="primary">Ver inventario completo</ion-button>
+      <ion-button expand="block" color="success">
+        <ion-icon slot="start" [icon]="addCircleOutline"></ion-icon>
+        Añadir nuevo producto
+      </ion-button>
+    </div>
+  </ion-card-content>
+</ion-card>

--- a/Market/src/app/providers/dashboard/widgets/inventory-widget.component.scss
+++ b/Market/src/app/providers/dashboard/widgets/inventory-widget.component.scss
@@ -1,0 +1,15 @@
+:host {
+  display: block;
+}
+
+.empty-message {
+  margin: 0 0 1rem;
+  color: var(--ion-color-medium);
+  text-align: center;
+}
+
+.widget-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}

--- a/Market/src/app/providers/dashboard/widgets/inventory-widget.component.ts
+++ b/Market/src/app/providers/dashboard/widgets/inventory-widget.component.ts
@@ -1,0 +1,50 @@
+import { Component, Input } from '@angular/core';
+import {
+  IonBadge,
+  IonButton,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
+import { addCircleOutline, createOutline, storefrontOutline } from 'ionicons/icons';
+
+export interface InventoryItem {
+  id: string;
+  name: string;
+  stock: number;
+}
+
+@Component({
+  selector: 'app-inventory-widget',
+  templateUrl: './inventory-widget.component.html',
+  styleUrls: ['./inventory-widget.component.scss'],
+  standalone: true,
+  imports: [
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonIcon,
+    IonBadge,
+    IonButton,
+  ],
+})
+export class InventoryWidgetComponent {
+  protected readonly storefrontOutline = storefrontOutline;
+  protected readonly createOutline = createOutline;
+  protected readonly addCircleOutline = addCircleOutline;
+
+  @Input() inventory: InventoryItem[] = [];
+
+  trackById(_index: number, item: InventoryItem): string {
+    return item.id;
+  }
+}

--- a/Market/src/app/providers/dashboard/widgets/services-widget.component.html
+++ b/Market/src/app/providers/dashboard/widgets/services-widget.component.html
@@ -1,0 +1,25 @@
+<ion-card>
+  <ion-card-header>
+    <ion-card-title>Servicios ofrecidos</ion-card-title>
+  </ion-card-header>
+  <ion-card-content>
+    <ion-list lines="none" *ngIf="services.length > 0; else emptyServices">
+      <ion-item *ngFor="let service of services">
+        <ion-icon slot="start" [icon]="listCircleOutline"></ion-icon>
+        <ion-label>
+          <h3>{{ service }}</h3>
+        </ion-label>
+      </ion-item>
+    </ion-list>
+
+    <ng-template #emptyServices>
+      <p class="empty-message">
+        Todavía no has configurado los servicios que ofreces. ¡Hazlo ahora para mostrarlos a tus clientes!
+      </p>
+      <ion-button expand="block" color="primary">
+        <ion-icon slot="start" [icon]="settingsOutline"></ion-icon>
+        Configurar servicios
+      </ion-button>
+    </ng-template>
+  </ion-card-content>
+</ion-card>

--- a/Market/src/app/providers/dashboard/widgets/services-widget.component.scss
+++ b/Market/src/app/providers/dashboard/widgets/services-widget.component.scss
@@ -1,0 +1,9 @@
+:host {
+  display: block;
+}
+
+.empty-message {
+  margin: 0 0 1rem;
+  text-align: center;
+  color: var(--ion-color-medium);
+}

--- a/Market/src/app/providers/dashboard/widgets/services-widget.component.ts
+++ b/Market/src/app/providers/dashboard/widgets/services-widget.component.ts
@@ -1,0 +1,37 @@
+import { Component, Input } from '@angular/core';
+import {
+  IonButton,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
+import { listCircleOutline, settingsOutline } from 'ionicons/icons';
+
+@Component({
+  selector: 'app-services-widget',
+  templateUrl: './services-widget.component.html',
+  styleUrls: ['./services-widget.component.scss'],
+  standalone: true,
+  imports: [
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonIcon,
+    IonButton,
+  ],
+})
+export class ServicesWidgetComponent {
+  protected readonly listCircleOutline = listCircleOutline;
+  protected readonly settingsOutline = settingsOutline;
+
+  @Input() services: string[] = [];
+}

--- a/Market/src/app/providers/dashboard/widgets/species-widget.component.html
+++ b/Market/src/app/providers/dashboard/widgets/species-widget.component.html
@@ -1,0 +1,25 @@
+<ion-card>
+  <ion-card-header>
+    <ion-card-title>Especies atendidas</ion-card-title>
+  </ion-card-header>
+  <ion-card-content>
+    <ion-list lines="none" *ngIf="species.length > 0; else emptySpecies">
+      <ion-item *ngFor="let specie of species">
+        <ion-icon slot="start" [icon]="pawOutline"></ion-icon>
+        <ion-label>
+          <h3>{{ specie }}</h3>
+        </ion-label>
+      </ion-item>
+    </ion-list>
+
+    <ng-template #emptySpecies>
+      <p class="empty-message">
+        Selecciona las especies que atiendes para que tus clientes sepan si puedes ayudarles.
+      </p>
+      <ion-button expand="block" color="primary">
+        <ion-icon slot="start" [icon]="settingsOutline"></ion-icon>
+        Configurar especies
+      </ion-button>
+    </ng-template>
+  </ion-card-content>
+</ion-card>

--- a/Market/src/app/providers/dashboard/widgets/species-widget.component.scss
+++ b/Market/src/app/providers/dashboard/widgets/species-widget.component.scss
@@ -1,0 +1,9 @@
+:host {
+  display: block;
+}
+
+.empty-message {
+  margin: 0 0 1rem;
+  text-align: center;
+  color: var(--ion-color-medium);
+}

--- a/Market/src/app/providers/dashboard/widgets/species-widget.component.ts
+++ b/Market/src/app/providers/dashboard/widgets/species-widget.component.ts
@@ -1,0 +1,37 @@
+import { Component, Input } from '@angular/core';
+import {
+  IonButton,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
+import { pawOutline, settingsOutline } from 'ionicons/icons';
+
+@Component({
+  selector: 'app-species-widget',
+  templateUrl: './species-widget.component.html',
+  styleUrls: ['./species-widget.component.scss'],
+  standalone: true,
+  imports: [
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonIcon,
+    IonButton,
+  ],
+})
+export class SpeciesWidgetComponent {
+  protected readonly pawOutline = pawOutline;
+  protected readonly settingsOutline = settingsOutline;
+
+  @Input() species: string[] = [];
+}

--- a/Market/src/app/providers/preferences/provider-preferences.page.html
+++ b/Market/src/app/providers/preferences/provider-preferences.page.html
@@ -1,0 +1,63 @@
+<ion-header translucent="true">
+  <ion-toolbar>
+    <ion-title>Configurar panel</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content fullscreen>
+  <form [formGroup]="form" (ngSubmit)="save()" class="preferences-form">
+    <section>
+      <h2>Selecciona los módulos que deseas ver</h2>
+      <ion-list lines="full" formGroupName="modules">
+        <ion-item>
+          <ion-label>Agenda de citas</ion-label>
+          <ion-checkbox slot="end" formControlName="agenda"></ion-checkbox>
+        </ion-item>
+        <ion-item>
+          <ion-label>Gestión de productos</ion-label>
+          <ion-checkbox slot="end" formControlName="inventory"></ion-checkbox>
+        </ion-item>
+        <ion-item>
+          <ion-label>Servicios ofrecidos</ion-label>
+          <ion-checkbox slot="end" formControlName="services"></ion-checkbox>
+        </ion-item>
+        <ion-item>
+          <ion-label>Especies atendidas</ion-label>
+          <ion-checkbox slot="end" formControlName="species"></ion-checkbox>
+        </ion-item>
+      </ion-list>
+    </section>
+
+    <section>
+      <h2>Información para mostrar</h2>
+      <ion-list lines="full">
+        <ion-item>
+          <ion-label position="stacked">Servicios ofrecidos</ion-label>
+          <ion-textarea
+            formControlName="servicesOffered"
+            autoGrow="true"
+            placeholder="Baños, esterilizaciones, hospitalización"
+          ></ion-textarea>
+          <p class="helper-text">Separa cada servicio con comas.</p>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">Especies atendidas</ion-label>
+          <ion-textarea
+            formControlName="speciesAttended"
+            autoGrow="true"
+            placeholder="Perros, gatos, animales exóticos"
+          ></ion-textarea>
+          <p class="helper-text">Separa cada especie con comas.</p>
+        </ion-item>
+      </ion-list>
+    </section>
+
+    <ion-footer>
+      <ion-toolbar>
+        <ion-button type="submit" expand="block" color="primary">
+          Guardar y ver dashboard
+        </ion-button>
+      </ion-toolbar>
+    </ion-footer>
+  </form>
+</ion-content>

--- a/Market/src/app/providers/preferences/provider-preferences.page.scss
+++ b/Market/src/app/providers/preferences/provider-preferences.page.scss
@@ -1,0 +1,31 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.preferences-form {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+section {
+  padding: 1.5rem 1.5rem 0;
+}
+
+section h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.helper-text {
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+  font-size: 0.85rem;
+  color: var(--ion-color-medium);
+}
+
+ion-footer {
+  margin-top: auto;
+}

--- a/Market/src/app/providers/preferences/provider-preferences.page.ts
+++ b/Market/src/app/providers/preferences/provider-preferences.page.ts
@@ -1,0 +1,98 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import {
+  IonButton,
+  IonCheckbox,
+  IonContent,
+  IonFooter,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonTextarea,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
+import { ProviderPreferences, ProviderPreferencesService } from '../services/provider-preferences.service';
+
+@Component({
+  selector: 'app-provider-preferences',
+  templateUrl: './provider-preferences.page.html',
+  styleUrls: ['./provider-preferences.page.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonCheckbox,
+    IonTextarea,
+    IonFooter,
+    IonButton,
+  ],
+})
+export class ProviderPreferencesPage {
+  private readonly fb = inject(FormBuilder);
+  private readonly preferencesService = inject(ProviderPreferencesService);
+  private readonly router = inject(Router);
+
+  protected readonly form: FormGroup = this.fb.group({
+    modules: this.fb.group({
+      agenda: [false],
+      inventory: [false],
+      services: [false],
+      species: [false],
+    }),
+    servicesOffered: [''],
+    speciesAttended: [''],
+  });
+
+  constructor() {
+    const preferences = this.preferencesService.getPreferences();
+    this.form.patchValue({
+      modules: preferences.modules,
+      servicesOffered: preferences.servicesOffered.join(', '),
+      speciesAttended: preferences.speciesAttended.join(', '),
+    });
+  }
+
+  protected save(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const formValue = this.form.value as {
+      modules: ProviderPreferences['modules'];
+      servicesOffered: string;
+      speciesAttended: string;
+    };
+
+    const preferences: ProviderPreferences = {
+      modules: formValue.modules,
+      servicesOffered: this.parseList(formValue.servicesOffered),
+      speciesAttended: this.parseList(formValue.speciesAttended),
+    };
+
+    this.preferencesService.savePreferences(preferences);
+    void this.router.navigate(['/providers/dashboard']);
+  }
+
+  private parseList(value: string | null | undefined): string[] {
+    if (!value) {
+      return [];
+    }
+
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  }
+}

--- a/Market/src/app/providers/services/provider-preferences.service.ts
+++ b/Market/src/app/providers/services/provider-preferences.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface ProviderPreferences {
+  modules: {
+    agenda: boolean;
+    inventory: boolean;
+    services: boolean;
+    species: boolean;
+  };
+  servicesOffered: string[];
+  speciesAttended: string[];
+}
+
+const DEFAULT_PREFERENCES: ProviderPreferences = {
+  modules: {
+    agenda: false,
+    inventory: false,
+    services: false,
+    species: false,
+  },
+  servicesOffered: [],
+  speciesAttended: [],
+};
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ProviderPreferencesService {
+  private readonly storageKey = 'provider-preferences';
+  private readonly preferencesSubject = new BehaviorSubject<ProviderPreferences>(
+    this.loadFromStorage(),
+  );
+
+  readonly preferences$ = this.preferencesSubject.asObservable();
+
+  getPreferences(): ProviderPreferences {
+    return this.preferencesSubject.value;
+  }
+
+  savePreferences(preferences: ProviderPreferences): void {
+    this.preferencesSubject.next(preferences);
+    this.persist(preferences);
+  }
+
+  private persist(preferences: ProviderPreferences): void {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+
+    localStorage.setItem(this.storageKey, JSON.stringify(preferences));
+  }
+
+  private loadFromStorage(): ProviderPreferences {
+    if (typeof localStorage === 'undefined') {
+      return DEFAULT_PREFERENCES;
+    }
+
+    const raw = localStorage.getItem(this.storageKey);
+
+    if (!raw) {
+      return DEFAULT_PREFERENCES;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as ProviderPreferences;
+      return {
+        ...DEFAULT_PREFERENCES,
+        ...parsed,
+        modules: {
+          ...DEFAULT_PREFERENCES.modules,
+          ...(parsed.modules ?? {}),
+        },
+        servicesOffered: parsed.servicesOffered ?? [],
+        speciesAttended: parsed.speciesAttended ?? [],
+      };
+    } catch {
+      return DEFAULT_PREFERENCES;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create a configurable providers dashboard composed of agenda, inventory, services, and species widgets with proper empty states
- add a provider preferences form and service to persist module visibility and contextual data
- wire providers routes so the dashboard loads after saving preferences and configuration can be reopened from the panel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2af0a90308324bf9f6e9a954df9c0