### PR TITLE
feat: initialize firebase configuration

### DIFF
--- a/marketpet/src/environments/environment.prod.ts
+++ b/marketpet/src/environments/environment.prod.ts
@@ -1,3 +1,12 @@
 export const environment = {
-  production: true
+  production: true,
+  firebase: {
+    apiKey: 'AIzaSyDajBLApflmVd7R06ami7NKdsrT0NDsfvo',
+    authDomain: 'marketpet-5bc0f.firebaseapp.com',
+    projectId: 'marketpet-5bc0f',
+    storageBucket: 'marketpet-5bc0f.firebasestorage.app',
+    messagingSenderId: '330809070804',
+    appId: '1:330809070804:web:8d3c92c58809a0e59b1741',
+    measurementId: 'G-PMGY8QNPEZ',
+  },
 };

--- a/marketpet/src/environments/environment.ts
+++ b/marketpet/src/environments/environment.ts
@@ -3,7 +3,16 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  firebase: {
+    apiKey: 'AIzaSyDajBLApflmVd7R06ami7NKdsrT0NDsfvo',
+    authDomain: 'marketpet-5bc0f.firebaseapp.com',
+    projectId: 'marketpet-5bc0f',
+    storageBucket: 'marketpet-5bc0f.firebasestorage.app',
+    messagingSenderId: '330809070804',
+    appId: '1:330809070804:web:8d3c92c58809a0e59b1741',
+    measurementId: 'G-PMGY8QNPEZ',
+  },
 };
 
 /*

--- a/marketpet/src/main.ts
+++ b/marketpet/src/main.ts
@@ -1,6 +1,47 @@
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.log(err));
+declare global {
+  interface Window {
+    firebase?: any;
+  }
+}
+
+const loadScript = (src: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Unable to load script ${src}`));
+    document.head.append(script);
+  });
+
+const initFirebase = async (): Promise<void> => {
+  if (typeof window === 'undefined' || !environment.firebase) {
+    return;
+  }
+
+  await loadScript('https://www.gstatic.com/firebasejs/11.0.0/firebase-app-compat.js');
+
+  const { firebase } = window;
+
+  if (!firebase) {
+    throw new Error('Firebase SDK not available');
+  }
+
+  firebase.initializeApp(environment.firebase);
+
+  if (environment.firebase.measurementId) {
+    await loadScript('https://www.gstatic.com/firebasejs/11.0.0/firebase-analytics-compat.js');
+    firebase.analytics();
+  }
+};
+
+void initFirebase().catch(err => console.error('Error initializing Firebase', err));
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- add firebase configuration for development and production environments
- load the Firebase SDK dynamically during bootstrap and initialize analytics when available

## Testing
- npm install --package-lock-only firebase@11.0.0 *(fails: registry access returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b02f2e0c8324978adf7489b4cbd3