### PR TITLE
feat: initialize firebase with angular fire

### DIFF
--- a/Market/angular.json
+++ b/Market/angular.json
@@ -151,7 +151,8 @@
   "cli": {
     "schematicCollections": [
       "@ionic/angular-toolkit"
-    ]
+    ],
+    "analytics": false
   },
   "schematics": {
     "@ionic/angular-toolkit:component": {

--- a/Market/src/environments/environment.prod.ts
+++ b/Market/src/environments/environment.prod.ts
@@ -1,3 +1,16 @@
-export const environment = {
-  production: true
+import type { FirebaseOptions } from 'firebase/app';
+
+const firebaseConfig: FirebaseOptions = {
+  apiKey: 'AIzaSyDajBLApflmVd7R06ami7NKdsrT0NDsfvo',
+  authDomain: 'marketpet-5bc0f.firebaseapp.com',
+  projectId: 'marketpet-5bc0f',
+  storageBucket: 'marketpet-5bc0f.firebasestorage.app',
+  messagingSenderId: '330809070804',
+  appId: '1:330809070804:web:8d3c92c58809a0e59b1741',
+  measurementId: 'G-PMGY8QNPEZ',
 };
+
+export const environment = {
+  production: true,
+  firebase: firebaseConfig,
+} as const;

--- a/Market/src/environments/environment.ts
+++ b/Market/src/environments/environment.ts
@@ -1,19 +1,30 @@
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
-// Importa el módulo dotenv para cargar las variables de entorno
-import * as dotenv from 'dotenv';
 
-// Configura las variables de entorno con dotenv.config()
+import * as dotenv from 'dotenv';
+import type { FirebaseOptions } from 'firebase/app';
+
 dotenv.config();
+
+const firebaseConfig: FirebaseOptions = {
+  apiKey: 'AIzaSyDajBLApflmVd7R06ami7NKdsrT0NDsfvo',
+  authDomain: 'marketpet-5bc0f.firebaseapp.com',
+  projectId: 'marketpet-5bc0f',
+  storageBucket: 'marketpet-5bc0f.firebasestorage.app',
+  messagingSenderId: '330809070804',
+  appId: '1:330809070804:web:8d3c92c58809a0e59b1741',
+  measurementId: 'G-PMGY8QNPEZ',
+};
 
 // Exporta la configuración de la aplicación
 export const environment = {
   // Indica si la aplicación está en modo producción o no
   production: false,
   // Utiliza la variable de entorno API_URL para configurar la URL de la API
-  apiUrl: process.env.API_URL
-};
+  apiUrl: process.env.API_URL,
+  firebase: firebaseConfig,
+} as const;
 /*
  * For easier debugging in development mode, you can import the following file
  * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.

--- a/Market/src/main.ts
+++ b/Market/src/main.ts
@@ -1,14 +1,32 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
 import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
+import type { Provider } from '@angular/core';
+
+import { provideFirebaseApp, initializeApp } from '@angular/fire/app';
+import { provideAnalytics, getAnalytics, ScreenTrackingService, UserTrackingService } from '@angular/fire/analytics';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
+import { environment } from './environments/environment';
+
+const firebaseProviders: Provider[] = [
+  provideFirebaseApp(() => initializeApp(environment.firebase)),
+];
+
+if (environment.firebase.measurementId) {
+  firebaseProviders.push(
+    provideAnalytics(() => getAnalytics()),
+    ScreenTrackingService,
+    UserTrackingService,
+  );
+}
 
 bootstrapApplication(AppComponent, {
   providers: [
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
+    ...firebaseProviders,
   ],
-});
+}).catch(error => console.error(error));


### PR DESCRIPTION
## Summary
- configure the environment files with typed Firebase options for both development and production builds
- bootstrap Firebase through AngularFire and register analytics services only when the measurement ID is available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2b02f2e0c8324978adf7489b4cbd3