### PR TITLE
Clean stray tokens and restore Angular bootstrap

### DIFF
--- a/Market/src/app/perfil-proveedor/perfil-proveedor.page.html
+++ b/Market/src/app/perfil-proveedor/perfil-proveedor.page.html
@@ -85,6 +85,5 @@
   </ion-card>
 
   <ion-button expand="block" (click)="agregarProducto()">Agregar Producto</ion-button>
-main
 </ion-content>
 

--- a/Market/src/app/perfil-proveedor/perfil-proveedor.page.spec.ts
+++ b/Market/src/app/perfil-proveedor/perfil-proveedor.page.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 import { ProviderDashboardService } from '../shared/services/provider-dashboard.service';
@@ -11,24 +10,18 @@ class ProviderDashboardServiceStub {
   getWidgets = jasmine.createSpy().and.returnValue([]);
 }
 
-=======
-import { PerfilProveedorPage } from './perfil-proveedor.page';
-
-main
 describe('PerfilProveedorPage', () => {
   let component: PerfilProveedorPage;
   let fixture: ComponentFixture<PerfilProveedorPage>;
-
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PerfilProveedorPage, RouterTestingModule],
       providers: [{ provide: ProviderDashboardService, useClass: ProviderDashboardServiceStub }],
     }).compileComponents();
+  });
 
-=======
   beforeEach(() => {
-main
     fixture = TestBed.createComponent(PerfilProveedorPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/Market/src/app/perfil-proveedor/perfil-proveedor.page.ts
+++ b/Market/src/app/perfil-proveedor/perfil-proveedor.page.ts
@@ -7,20 +7,11 @@ import { IonicModule } from '@ionic/angular';
 import { DashboardWidget, ProviderDashboardService } from '../shared/services/provider-dashboard.service';
 import { map } from 'rxjs';
 
-import { Component } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-main
-
 @Component({
   selector: 'app-perfil-proveedor',
   standalone: true,
 
   imports: [IonicModule, CommonModule, FormsModule, RouterModule],
-
-  imports: [IonicModule, CommonModule, FormsModule],
-main
   templateUrl: './perfil-proveedor.page.html',
   styleUrls: ['./perfil-proveedor.page.scss'],
 })
@@ -37,6 +28,7 @@ export class PerfilProveedorPage {
 
   trackWidget(_: number, widget: DashboardWidget): string {
     return widget.id;
+  }
 
   servicios = [
     { nombre: 'Peluquería a domicilio', modalidad: 'Domicilio', precio: 20000 },
@@ -52,7 +44,6 @@ export class PerfilProveedorPage {
 
   agregarProducto() {
     this.productos.push({ nombre: '', precio: 0 });
-main
   }
 }
 

--- a/Market/src/app/registro/registro.page.html
+++ b/Market/src/app/registro/registro.page.html
@@ -5,11 +5,7 @@
 </ion-header>
 
 <ion-content class="ion-padding">
-
   <form [formGroup]="registroForm" (ngSubmit)="onSubmit()" class="registro-form">
-
-  <form [formGroup]="registroForm" (ngSubmit)="onSubmit()">
- main
     <ion-item>
       <ion-label>Rol</ion-label>
       <ion-segment formControlName="role">
@@ -19,30 +15,18 @@
     </ion-item>
 
     <!-- Campo dinámico según rol -->
-
     <ion-item *ngIf="isProveedor()">
-
-    <ion-item *ngIf="registroForm.get('role')?.value === 'proveedor'">
-main
       <ion-label position="floating">Nombre o Razón Social</ion-label>
       <ion-input formControlName="nombre"></ion-input>
     </ion-item>
 
-
     <ion-item *ngIf="!isProveedor()">
-
-    <ion-item *ngIf="registroForm.get('role')?.value === 'cliente'">
-main
       <ion-label position="floating">Nombre</ion-label>
       <ion-input formControlName="nombre"></ion-input>
     </ion-item>
 
     <!-- RUT solo para proveedores -->
-
     <ion-item *ngIf="isProveedor()">
-
-    <ion-item *ngIf="registroForm.get('role')?.value === 'proveedor'">
-main
       <ion-label position="floating">RUT</ion-label>
       <ion-input formControlName="rut"></ion-input>
     </ion-item>
@@ -66,7 +50,6 @@ main
       <ion-label position="floating">Contraseña</ion-label>
       <ion-input type="password" formControlName="password"></ion-input>
     </ion-item>
-
 
     <section *ngIf="isProveedor()" class="survey">
       <h2>Servicios que ofreces</h2>
@@ -149,9 +132,6 @@ main
     <ion-text color="danger" *ngIf="errorMessage()">
       <p class="error-text">{{ errorMessage() }}</p>
     </ion-text>
-
-    <ion-button expand="block" type="submit" class="ion-margin-top">Registrarse</ion-button>
- main
   </form>
 
   <div class="ion-text-center ion-margin-top">
@@ -159,4 +139,3 @@ main
     <ion-button fill="clear" [routerLink]="['/login']">Iniciar Sesión</ion-button>
   </div>
 </ion-content>
-

--- a/Market/src/app/registro/registro.page.spec.ts
+++ b/Market/src/app/registro/registro.page.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 import { FirebaseCrudService } from '../shared/services/firebase-crud.service';
@@ -16,14 +15,9 @@ class FirebaseCrudServiceStub {
   setDocument = jasmine.createSpy().and.returnValue(Promise.resolve());
 }
 
-
-
-import { RegistroPage } from './registro.page';
-main
 describe('RegistroPage', () => {
   let component: RegistroPage;
   let fixture: ComponentFixture<RegistroPage>;
-
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -33,10 +27,9 @@ describe('RegistroPage', () => {
         { provide: FirebaseCrudService, useClass: FirebaseCrudServiceStub },
       ],
     }).compileComponents();
-
+  });
 
   beforeEach(() => {
- main
     fixture = TestBed.createComponent(RegistroPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/Market/src/app/registro/registro.page.ts
+++ b/Market/src/app/registro/registro.page.ts
@@ -45,12 +45,6 @@ function atLeastOneService(control: AbstractControl): ValidationErrors | null {
   return formArray.length > 0 ? null : { required: true };
 }
 
-import { Component, inject } from '@angular/core';
-import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { RouterModule } from '@angular/router';
-import { IonicModule } from '@ionic/angular';
- main
-
 @Component({
   selector: 'app-registro',
   standalone: true,
@@ -278,26 +272,5 @@ export class RegistroPage {
     } finally {
       this.saving.set(false);
     }
-
-
-  readonly registroForm = this.fb.group({
-    role: ['cliente', Validators.required],
-    nombre: ['', Validators.required],
-    rut: [''],
-    direccion: ['', Validators.required],
-    telefono: ['', Validators.required],
-    email: ['', [Validators.required, Validators.email]],
-    password: ['', Validators.required],
-  });
-
-  onSubmit(): void {
-    if (this.registroForm.invalid) {
-      this.registroForm.markAllAsTouched();
-      return;
-    }
-
-    const datos = this.registroForm.value;
-    console.log('Registro con:', datos);
- main
   }
 }

--- a/Market/src/main.ts
+++ b/Market/src/main.ts
@@ -6,7 +6,6 @@ import { provideFirebaseApp, initializeApp } from '@angular/fire/app';
 import { provideAuth, getAuth } from '@angular/fire/auth';
 import { provideFirestore, getFirestore } from '@angular/fire/firestore';
 import { provideStorage, getStorage } from '@angular/fire/storage';
- main
 
 import { AppComponent } from './app/app.component';
 import { routes } from './app/app.routes';
@@ -52,7 +51,6 @@ const initFirebase = async (): Promise<void> => {
 
 void initFirebase().catch(error => console.error('Error initializing Firebase', error));
 
- main
 bootstrapApplication(AppComponent, {
   providers: [
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
@@ -63,6 +61,5 @@ bootstrapApplication(AppComponent, {
     provideAuth(() => getAuth()),
     provideFirestore(() => getFirestore()),
     provideStorage(() => getStorage()),
-main
   ],
 }).catch(error => console.error(error));


### PR DESCRIPTION
## Summary
- remove stray `main` tokens so the Angular entrypoint and related components compile again
- rebuild the Registro and Perfil Proveedor pages/templates/specs without duplicated declarations or conflict markers
- clean up provider dashboard component logic so only the intended providers remain

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a66856cc8324af539994d6dd286e