### PR TITLE
Fix sign-up route and clean bootstrap configuration

### DIFF
--- a/Market/src/app/app.routes.ts
+++ b/Market/src/app/app.routes.ts
@@ -28,7 +28,7 @@ export const routes: Routes = [
   },
   {
     path: 'registro',
-    loadComponent: () => import('./registro/registro.page').then(m => m.RegistroPage),
+    loadComponent: () => import('./pages/auth/sign-up/sign-up.page').then(m => m.SignUpPage),
   },
   {
     path: 'perfil-cliente',

--- a/Market/src/main.ts
+++ b/Market/src/main.ts
@@ -6,12 +6,10 @@ import { provideFirebaseApp, initializeApp } from '@angular/fire/app';
 import { provideAuth, getAuth } from '@angular/fire/auth';
 import { provideFirestore, getFirestore } from '@angular/fire/firestore';
 import { provideStorage, getStorage } from '@angular/fire/storage';
- main
 
 import { AppComponent } from './app/app.component';
 import { routes } from './app/app.routes';
 import { environment } from './environments/environment';
-
 
 declare global {
   interface Window {
@@ -52,17 +50,14 @@ const initFirebase = async (): Promise<void> => {
 
 void initFirebase().catch(error => console.error('Error initializing Firebase', error));
 
- main
 bootstrapApplication(AppComponent, {
   providers: [
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
-
     provideFirebaseApp(() => initializeApp(environment.firebase)),
     provideAuth(() => getAuth()),
     provideFirestore(() => getFirestore()),
     provideStorage(() => getStorage()),
-main
   ],
 }).catch(error => console.error(error));


### PR DESCRIPTION
## Summary
- point the registro route to the existing sign-up standalone component
- clean stray tokens from main bootstrap file and restore firebase initialization

## Testing
- npm run build -- --configuration development

------
https://chatgpt.com/codex/tasks/task_e_68d9c5603a7c832481338a09f511e5a1