### PR TITLE
feat: refresh Market home layout with new design

### DIFF
--- a/Market/src/app/home/home.page.html
+++ b/Market/src/app/home/home.page.html
@@ -1,22 +1,219 @@
-<ion-header>
-  <ion-toolbar color="primary">
-    <ion-title>MarketPet</ion-title>
+<ion-header translucent="true" class="home-header">
+  <ion-toolbar>
+    <div class="header-content">
+      <div class="branding">
+        <div class="logo">
+          <ion-icon name="heart" />
+        </div>
+        <div>
+          <h1>MarketPet</h1>
+          <p>Marketplace de bienestar animal</p>
+        </div>
+      </div>
+
+      <div class="header-actions">
+        <ion-badge color="tertiary" class="plan-badge">
+          Plan {{ user.planType }}
+        </ion-badge>
+        <ion-button fill="clear" size="small" class="icon-button" aria-label="Notificaciones">
+          <ion-icon slot="icon-only" name="notifications-outline" />
+        </ion-button>
+        <ion-button fill="clear" size="small" class="icon-button" aria-label="Perfil" [routerLink]="['/perfil-cliente']">
+          <ion-icon slot="icon-only" name="person-circle-outline" />
+        </ion-button>
+      </div>
+    </div>
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="ion-padding ion-text-center">
-  <h1>Bienvenido a MarketPet</h1>
-  <p>Tu marketplace para productos y servicios de mascotas.</p>
+<ion-content [fullscreen]="true" class="home-content">
+  <div class="page-padding">
+    <ion-card class="welcome-card">
+      <ion-card-header>
+        <ion-card-subtitle>Hola, {{ user.name }}</ion-card-subtitle>
+        <ion-card-title>Organiza el cuidado de tus mascotas desde un solo lugar</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <div class="welcome-meta">
+          <div class="meta-item">
+            <ion-icon name="location-outline" />
+            <span>{{ user.location }}</span>
+          </div>
+          <div class="meta-item">
+            <ion-icon name="call-outline" />
+            <span>{{ user.phone }}</span>
+          </div>
+        </div>
+        <ion-button expand="block" class="primary-action" [routerLink]="['/feed']">
+          <ion-icon slot="start" name="search-outline" />
+          Buscar proveedores
+        </ion-button>
+      </ion-card-content>
+    </ion-card>
 
-  <ion-button expand="block" color="secondary" [routerLink]="['/auth']">
-    Iniciar Sesión
-  </ion-button>
+    <section class="section">
+      <div class="section-header">
+        <h2>Acciones rápidas</h2>
+        <ion-button fill="clear" size="small">Ver todas</ion-button>
+      </div>
+      <div class="quick-actions">
+        <ion-card
+          class="quick-action"
+          *ngFor="let action of quickActions; trackBy: trackByIndex"
+          [ngClass]="'quick-action--' + action.color"
+          [routerLink]="action.routerLink"
+        >
+          <ion-card-content>
+            <div class="quick-action__icon">
+              <ion-icon [name]="action.icon" />
+            </div>
+            <div>
+              <h3>{{ action.label }}</h3>
+              <p>{{ action.description }}</p>
+            </div>
+          </ion-card-content>
+        </ion-card>
+      </div>
+    </section>
 
-  <ion-button expand="block" color="tertiary" [routerLink]="['/registro']">
-    Registrarse
-  </ion-button>
+    <section class="section">
+      <div class="section-header">
+        <h2>Tus mascotas</h2>
+        <ion-button fill="clear" size="small">Añadir mascota</ion-button>
+      </div>
+      <div class="horizontal-scroll">
+        <ion-card class="pet-card" *ngFor="let pet of pets; trackBy: trackByIndex">
+          <ion-card-header>
+            <ion-card-subtitle>{{ pet.species }}</ion-card-subtitle>
+            <ion-card-title>{{ pet.name }}</ion-card-title>
+          </ion-card-header>
+          <ion-card-content>
+            <div class="pet-card__details">
+              <div>
+                <span class="label">Raza</span>
+                <strong>{{ pet.breed }}</strong>
+              </div>
+              <div>
+                <span class="label">Edad</span>
+                <strong>{{ pet.age }}</strong>
+              </div>
+              <div>
+                <span class="label">Peso</span>
+                <strong>{{ pet.weight }}</strong>
+              </div>
+            </div>
+            <div class="pet-card__vaccines">
+              <span class="label">Vacunas</span>
+              <ion-chip color="light" *ngFor="let vaccine of pet.vaccinations; trackBy: trackByIndex">
+                <ion-icon name="shield-checkmark-outline" />
+                <ion-label>{{ vaccine }}</ion-label>
+              </ion-chip>
+            </div>
+          </ion-card-content>
+        </ion-card>
+      </div>
+    </section>
 
-  <ion-button expand="block" color="success" [routerLink]="['/feed']">
-    Ver Marketplace
-  </ion-button>
+    <section class="section">
+      <div class="section-header">
+        <h2>Próximas citas</h2>
+        <ion-button fill="clear" size="small">Ver historial</ion-button>
+      </div>
+      <ion-list class="appointment-list">
+        <ion-item *ngFor="let appointment of appointments; trackBy: trackByIndex">
+          <ion-icon name="calendar-clear-outline" slot="start" class="appointment-icon" />
+          <ion-label>
+            <h3>{{ appointment.service }}</h3>
+            <p>
+              {{ appointment.petName }} · {{ appointment.providerName }}
+            </p>
+            <p class="secondary">
+              {{ appointment.date }} · {{ appointment.time }} hrs
+            </p>
+          </ion-label>
+          <ion-badge slot="end" [color]="statusBadgeColor[appointment.status]">
+            {{ appointment.status === 'confirmed' ? 'Confirmada' : appointment.status === 'pending' ? 'Pendiente' : 'Completada' }}
+          </ion-badge>
+        </ion-item>
+      </ion-list>
+    </section>
+
+    <section class="section">
+      <div class="section-header">
+        <h2>Proveedores destacados</h2>
+        <ion-button fill="clear" size="small">Ver todos</ion-button>
+      </div>
+      <div class="vertical-stack">
+        <ion-card class="provider-card" *ngFor="let provider of providers; trackBy: trackByIndex">
+          <img [src]="provider.imageUrl" [alt]="provider.name" loading="lazy" />
+          <ion-card-content>
+            <div class="provider-card__header">
+              <div>
+                <h3>{{ provider.name }}</h3>
+                <p>{{ provider.profession }} · {{ provider.location }}</p>
+              </div>
+              <div class="provider-card__rating">
+                <ion-icon name="star" />
+                <span>{{ provider.rating }}</span>
+                <small>({{ provider.reviewCount }})</small>
+              </div>
+            </div>
+            <div class="provider-card__specialties">
+              <ion-chip color="secondary" *ngFor="let specialty of provider.specialties; trackBy: trackByIndex">
+                <ion-label>{{ specialty }}</ion-label>
+              </ion-chip>
+            </div>
+            <div class="provider-card__meta">
+              <div>
+                <ion-icon name="time-outline" />
+                <span>{{ provider.availability }}</span>
+              </div>
+              <div>
+                <ion-icon name="pricetag-outline" />
+                <span>{{ provider.price }}</span>
+              </div>
+            </div>
+            <ion-button expand="block" fill="outline" color="primary" [routerLink]="['/feed']">
+              Contactar
+            </ion-button>
+          </ion-card-content>
+        </ion-card>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-header">
+        <h2>Planes de suscripción</h2>
+        <ion-button fill="clear" size="small">Comparar planes</ion-button>
+      </div>
+      <div class="plan-grid">
+        <ion-card
+          class="plan-card"
+          *ngFor="let plan of subscriptionPlans; trackBy: trackByIndex"
+          [ngClass]="{ 'plan-card--current': plan.isCurrentPlan, 'plan-card--popular': plan.isPopular }"
+        >
+          <ion-card-header>
+            <ion-card-subtitle *ngIf="plan.isCurrentPlan">Plan actual</ion-card-subtitle>
+            <ion-card-subtitle *ngIf="plan.isPopular && !plan.isCurrentPlan">Más popular</ion-card-subtitle>
+            <ion-card-title>{{ plan.name }}</ion-card-title>
+          </ion-card-header>
+          <ion-card-content>
+            <div class="plan-card__price">
+              <span>{{ plan.price }}</span>
+              <small>/{{ plan.period }}</small>
+            </div>
+            <ul>
+              <li *ngFor="let feature of plan.features; trackBy: trackByIndex">
+                <ion-icon name="checkmark-circle-outline" />
+                <span>{{ feature }}</span>
+              </li>
+            </ul>
+            <ion-button expand="block" [fill]="plan.isCurrentPlan ? 'solid' : 'outline'" color="primary">
+              {{ plan.isCurrentPlan ? 'Gestionar plan' : 'Mejorar plan' }}
+            </ion-button>
+          </ion-card-content>
+        </ion-card>
+      </div>
+    </section>
+  </div>
 </ion-content>

--- a/Market/src/app/home/home.page.scss
+++ b/Market/src/app/home/home.page.scss
@@ -1,10 +1,485 @@
-ion-card img {
-  width: 100%;
-  height: auto;
-  border-radius: 8px;
+:host {
+  ion-content {
+    --background: var(--ion-color-light-tint, #f6f8fb);
+  }
 }
 
-h2 {
-  text-align: center;
-  margin-bottom: 20px;
+.home-header {
+  ion-toolbar {
+    --background: rgba(255, 255, 255, 0.95);
+    --border-width: 0 0 1px 0;
+    --border-color: var(--ion-color-step-150, #e5e7eb);
+    backdrop-filter: blur(12px);
+  }
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+
+  h1 {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 700;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--ion-color-medium-shade);
+  }
+}
+
+.logo {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, var(--ion-color-primary), var(--ion-color-tertiary));
+  display: grid;
+  place-items: center;
+
+  ion-icon {
+    color: #fff;
+    font-size: 1.3rem;
+  }
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.plan-badge {
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+}
+
+.icon-button {
+  --padding-start: 0.25rem;
+  --padding-end: 0.25rem;
+  --padding-top: 0.25rem;
+  --padding-bottom: 0.25rem;
+}
+
+.page-padding {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.25rem 1rem 2rem;
+}
+
+.welcome-card {
+  border-radius: 1.25rem;
+  background: linear-gradient(160deg, rgba(79, 70, 229, 0.12), rgba(99, 102, 241, 0.08));
+
+  ion-card-title {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: var(--ion-color-primary);
+  }
+
+  .welcome-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.5rem;
+    margin: 1rem 0;
+
+    .meta-item {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.85rem;
+      color: var(--ion-color-medium);
+
+      ion-icon {
+        color: var(--ion-color-primary);
+        font-size: 1rem;
+      }
+    }
+  }
+
+  .primary-action {
+    --border-radius: 999px;
+    --padding-top: 0.9rem;
+    --padding-bottom: 0.9rem;
+    font-weight: 600;
+  }
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 700;
+  }
+
+  ion-button {
+    --padding-start: 0.5rem;
+    --padding-end: 0.5rem;
+    --padding-top: 0.25rem;
+    --padding-bottom: 0.25rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+}
+
+.quick-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.quick-action {
+  border-radius: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 25px -15px rgba(0, 0, 0, 0.25);
+  }
+
+  ion-card-content {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0.25rem 0 0;
+    font-size: 0.82rem;
+    color: var(--ion-color-medium);
+  }
+}
+
+.quick-action__icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.25);
+
+  ion-icon {
+    font-size: 1.3rem;
+    color: #fff;
+  }
+}
+
+.quick-action--primary {
+  background: linear-gradient(140deg, var(--ion-color-primary), var(--ion-color-primary-tint));
+  color: #fff;
+}
+
+.quick-action--success {
+  background: linear-gradient(140deg, var(--ion-color-success), var(--ion-color-success-tint));
+  color: #fff;
+}
+
+.quick-action--warning {
+  background: linear-gradient(140deg, var(--ion-color-warning), var(--ion-color-warning-tint));
+  color: #fff;
+}
+
+.horizontal-scroll {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+  scroll-snap-type: x mandatory;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.pet-card {
+  min-width: 240px;
+  border-radius: 1.25rem;
+  scroll-snap-align: start;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(236, 233, 255, 0.65));
+
+  ion-card-subtitle {
+    color: var(--ion-color-medium);
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+  }
+
+  ion-card-title {
+    font-size: 1.2rem;
+    font-weight: 700;
+  }
+
+  &__details {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+    text-align: center;
+
+    .label {
+      font-size: 0.65rem;
+      color: var(--ion-color-medium);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    strong {
+      display: block;
+      font-size: 0.95rem;
+      margin-top: 0.15rem;
+    }
+  }
+
+  &__vaccines {
+    margin-top: 0.75rem;
+
+    .label {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--ion-color-medium);
+      margin-bottom: 0.35rem;
+    }
+
+    ion-chip {
+      margin-right: 0.35rem;
+      margin-bottom: 0.35rem;
+      --background: rgba(255, 255, 255, 0.6);
+      ion-icon {
+        margin-right: 0.25rem;
+        color: var(--ion-color-success);
+      }
+    }
+  }
+}
+
+.appointment-list {
+  border-radius: 1rem;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.85);
+
+  ion-item {
+    --padding-start: 0.75rem;
+    --inner-padding-end: 0.75rem;
+    --background: transparent;
+  }
+
+  h3 {
+    margin: 0 0 0.25rem;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.82rem;
+  }
+
+  .secondary {
+    color: var(--ion-color-medium);
+  }
+
+  .appointment-icon {
+    font-size: 1.3rem;
+    color: var(--ion-color-primary);
+  }
+}
+
+.vertical-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.provider-card {
+  border-radius: 1.25rem;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 160px;
+    object-fit: cover;
+  }
+
+  ion-card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+
+  h3 {
+    margin: 0 0 0.25rem;
+    font-size: 1.05rem;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--ion-color-medium);
+  }
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  &__rating {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-weight: 600;
+
+    ion-icon {
+      color: #f6c035;
+    }
+
+    small {
+      color: var(--ion-color-medium);
+    }
+  }
+
+  &__specialties {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  &__meta {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+
+    div {
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.85rem;
+      color: var(--ion-color-medium);
+
+      ion-icon {
+        color: var(--ion-color-primary);
+      }
+    }
+  }
+
+  ion-button {
+    --border-radius: 0.75rem;
+    font-weight: 600;
+  }
+}
+
+.plan-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .plan-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .quick-actions {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.plan-card {
+  border-radius: 1.25rem;
+  position: relative;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(99, 102, 241, 0.1);
+
+  ion-card-subtitle {
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    color: var(--ion-color-medium);
+  }
+
+  ion-card-title {
+    font-size: 1.2rem;
+    font-weight: 700;
+  }
+
+  &__price {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    margin-bottom: 0.75rem;
+
+    span {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--ion-color-primary);
+    }
+
+    small {
+      font-size: 0.85rem;
+      color: var(--ion-color-medium);
+    }
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: grid;
+    gap: 0.5rem;
+
+    li {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      color: var(--ion-color-medium);
+
+      ion-icon {
+        color: var(--ion-color-success);
+      }
+    }
+  }
+
+  ion-button {
+    --border-radius: 0.75rem;
+    font-weight: 600;
+  }
+}
+
+.plan-card--current {
+  border: 2px solid var(--ion-color-primary);
+  box-shadow: 0 10px 35px -20px rgba(79, 70, 229, 0.6);
+}
+
+.plan-card--popular {
+  border: 2px solid var(--ion-color-warning);
+  box-shadow: 0 12px 40px -22px rgba(251, 191, 36, 0.65);
 }

--- a/Market/src/app/home/home.page.ts
+++ b/Market/src/app/home/home.page.ts
@@ -1,14 +1,237 @@
 import { Component } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { IonicModule } from '@ionic/angular';
+
+interface PetProfile {
+  name: string;
+  species: string;
+  breed: string;
+  age: string;
+  weight: string;
+  vaccinations: string[];
+  location: string;
+}
+
+interface ProviderProfile {
+  name: string;
+  profession: string;
+  specialties: string[];
+  rating: number;
+  reviewCount: number;
+  location: string;
+  availability: string;
+  price: string;
+  imageUrl: string;
+}
+
+interface SubscriptionPlan {
+  name: string;
+  price: string;
+  period: string;
+  features: string[];
+  isCurrentPlan?: boolean;
+  isPopular?: boolean;
+}
+
+interface Appointment {
+  id: string;
+  petName: string;
+  providerName: string;
+  service: string;
+  date: string;
+  time: string;
+  status: 'confirmed' | 'pending' | 'completed';
+}
+
+interface QuickAction {
+  icon: string;
+  label: string;
+  description: string;
+  color: string;
+  routerLink?: string[];
+}
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [IonicModule, CommonModule, RouterModule],
+  imports: [CommonModule, IonicModule, RouterModule],
   templateUrl: './home.page.html',
   styleUrls: ['./home.page.scss'],
 })
-export class HomePage {}
+export class HomePage {
+  readonly user = {
+    name: 'Valentina',
+    planType: 'Básico',
+    email: 'valentina.rios@email.com',
+    phone: '+569 1234 5678',
+    location: 'Santiago Centro',
+  };
 
+  readonly quickActions: QuickAction[] = [
+    {
+      icon: 'calendar-outline',
+      label: 'Agendar cita',
+      description: 'Coordina servicios y consultas',
+      color: 'primary',
+      routerLink: ['/feed'],
+    },
+    {
+      icon: 'medkit-outline',
+      label: 'Vacunas',
+      description: 'Registra y programa vacunas',
+      color: 'success',
+    },
+    {
+      icon: 'sparkles-outline',
+      label: 'Suscripción',
+      description: 'Mejora tu plan',
+      color: 'warning',
+      routerLink: ['/perfil-cliente'],
+    },
+  ];
+
+  readonly pets: PetProfile[] = [
+    {
+      name: 'Max',
+      species: 'Perro',
+      breed: 'Golden Retriever',
+      age: '3 años',
+      weight: '28 kg',
+      vaccinations: ['Rabia', 'Parvovirus', 'Distemper'],
+      location: 'Santiago Centro',
+    },
+    {
+      name: 'Luna',
+      species: 'Gato',
+      breed: 'Persa',
+      age: '2 años',
+      weight: '4 kg',
+      vaccinations: ['Triple Felina', 'Rabia'],
+      location: 'Santiago Centro',
+    },
+    {
+      name: 'Rocky',
+      species: 'Perro',
+      breed: 'Bulldog Francés',
+      age: '5 años',
+      weight: '12 kg',
+      vaccinations: ['Rabia', 'Parvovirus'],
+      location: 'Santiago Centro',
+    },
+  ];
+
+  readonly providers: ProviderProfile[] = [
+    {
+      name: 'Dr. María González',
+      profession: 'Veterinaria',
+      specialties: ['Cirugía', 'Medicina Interna', 'Cardiología'],
+      rating: 4.9,
+      reviewCount: 127,
+      location: 'Las Condes, Santiago',
+      availability: 'Lun-Vie 9:00-18:00',
+      price: '$35.000',
+      imageUrl:
+        'https://images.unsplash.com/photo-1593275497414-473e94a9152a?auto=format&fit=crop&w=600&q=80',
+    },
+    {
+      name: 'Carlos Mendoza',
+      profession: 'Paseador Profesional',
+      specialties: ['Perros Grandes', 'Entrenamiento Básico', 'Ejercicio'],
+      rating: 4.8,
+      reviewCount: 89,
+      location: 'Parque Forestal, Santiago',
+      availability: 'Todos los días 7:00-19:00',
+      price: '$8.000/paseo',
+      imageUrl:
+        'https://images.unsplash.com/photo-1596787693095-1731f91546f8?auto=format&fit=crop&w=600&q=80',
+    },
+    {
+      name: 'Ana Silva',
+      profession: 'Estilista Canina',
+      specialties: ['Grooming', 'Corte de Uñas', 'Limpieza de Oídos'],
+      rating: 4.7,
+      reviewCount: 156,
+      location: 'Providencia, Santiago',
+      availability: 'Mar-Sáb 10:00-17:00',
+      price: '$25.000',
+      imageUrl:
+        'https://images.unsplash.com/photo-1625279138836-e7311d5c863a?auto=format&fit=crop&w=600&q=80',
+    },
+  ];
+
+  readonly subscriptionPlans: SubscriptionPlan[] = [
+    {
+      name: 'Básico',
+      price: 'Gratis',
+      period: 'mes',
+      features: [
+        'Hasta 2 perfiles de mascotas',
+        'Búsqueda básica de proveedores',
+        'Reservas estándar',
+        'Recordatorios básicos',
+      ],
+      isCurrentPlan: true,
+    },
+    {
+      name: 'Premium',
+      price: '$9.990',
+      period: 'mes',
+      features: [
+        'Perfiles ilimitados de mascotas',
+        'Reservas prioritarias',
+        'Descuentos del 15% en servicios',
+        'Recordatorios inteligentes de salud',
+        'Historial médico detallado',
+        'Soporte 24/7',
+      ],
+      isPopular: true,
+    },
+    {
+      name: 'Familiar',
+      price: '$15.990',
+      period: 'mes',
+      features: [
+        'Todo lo del plan Premium',
+        'Hasta 10 perfiles de mascotas',
+        'Descuentos del 25% en servicios',
+        'Plan de salud personalizado',
+        'Consultoría veterinaria mensual',
+        'Aplicación para toda la familia',
+      ],
+    },
+  ];
+
+  readonly appointments: Appointment[] = [
+    {
+      id: '1',
+      petName: 'Max',
+      providerName: 'Dr. María González',
+      service: 'Consulta General',
+      date: '22 de octubre',
+      time: '10:30',
+      status: 'confirmed',
+    },
+    {
+      id: '2',
+      petName: 'Luna',
+      providerName: 'Carlos Mendoza',
+      service: 'Paseo Vespertino',
+      date: '23 de octubre',
+      time: '18:00',
+      status: 'pending',
+    },
+  ];
+
+  get statusBadgeColor(): Record<Appointment['status'], string> {
+    return {
+      confirmed: 'success',
+      pending: 'warning',
+      completed: 'medium',
+    };
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+}

--- a/Market/src/app/perfil-proveedor/perfil-proveedor.page.spec.ts
+++ b/Market/src/app/perfil-proveedor/perfil-proveedor.page.spec.ts
@@ -1,24 +1,20 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
-import { ProviderDashboardService } from '../shared/services/provider-dashboard.service';
 import { PerfilProveedorPage } from './perfil-proveedor.page';
+import { ProviderDashboardService, DashboardWidget } from '../shared/services/provider-dashboard.service';
 
 class ProviderDashboardServiceStub {
   readonly profile$ = of(null);
 
-  getWidgets = jasmine.createSpy().and.returnValue([]);
+  getWidgets(): DashboardWidget[] {
+    return [];
+  }
 }
 
-=======
-import { PerfilProveedorPage } from './perfil-proveedor.page';
-
-main
 describe('PerfilProveedorPage', () => {
   let component: PerfilProveedorPage;
   let fixture: ComponentFixture<PerfilProveedorPage>;
-
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -26,9 +22,6 @@ describe('PerfilProveedorPage', () => {
       providers: [{ provide: ProviderDashboardService, useClass: ProviderDashboardServiceStub }],
     }).compileComponents();
 
-=======
-  beforeEach(() => {
-main
     fixture = TestBed.createComponent(PerfilProveedorPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/Market/src/app/perfil-proveedor/registro/registro.page.ts
+++ b/Market/src/app/perfil-proveedor/registro/registro.page.ts
@@ -44,12 +44,6 @@ function atLeastOneService(control: AbstractControl): ValidationErrors | null {
   return formArray.length > 0 ? null : { required: true };
 }
 
-import { Component, inject } from '@angular/core';
-import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { RouterModule } from '@angular/router';
-import { IonicModule } from '@ionic/angular';
- main
-
 @Component({
   selector: 'app-registro',
   standalone: true,
@@ -277,26 +271,5 @@ export class RegistroPage {
     } finally {
       this.saving.set(false);
     }
-
-
-  readonly registroForm = this.fb.group({
-    role: ['cliente', Validators.required],
-    nombre: ['', Validators.required],
-    rut: [''],
-    direccion: ['', Validators.required],
-    telefono: ['', Validators.required],
-    email: ['', [Validators.required, Validators.email]],
-    password: ['', Validators.required],
-  });
-
-  onSubmit(): void {
-    if (this.registroForm.invalid) {
-      this.registroForm.markAllAsTouched();
-      return;
-    }
-
-    const datos = this.registroForm.value;
-    console.log('Registro con:', datos);
- main
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the Market home page to include quick actions, pet profiles, upcoming appointments, featured providers, and subscription plans based on the new Figma design
- add a full design pass for the home view with gradients, responsive grids, and horizontal scrollers tailored to Ionic
- clean up leftover merge conflicts in provider registration files and update the provider spec to use a stub service

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da1f3fe9b88324a44f4e379ba49f8d